### PR TITLE
Add Angular 17 inventory system skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# Sample-AI-Generated
+# Inventory System (Angular 17)
+
+This is a sample Inventory System built with Angular 17. The project demonstrates a component based architecture, lazy loaded modules, services, reactive forms and Material design.
+
+## Features
+
+- Dashboard with chart summarizing inventory quantities
+- Inventory list view with search and CRUD actions
+- Item detail form for creating and editing items
+- Responsive layout using Angular Material
+- Lazy loaded feature modules
+- Data service using RxJS and HttpClient
+
+## Folder Structure
+
+```
+├── angular.json
+├── package.json
+├── src
+│   ├── index.html
+│   ├── main.ts
+│   ├── styles.scss
+│   ├── assets
+│   │   └── data
+│   │       └── inventory.json
+│   ├── environments
+│   │   ├── environment.ts
+│   │   └── environment.prod.ts
+│   └── app
+│       ├── app.component.*
+│       ├── app.module.ts
+│       ├── app.routes.ts
+│       └── features
+│           ├── dashboard
+│           └── inventory
+```
+
+## Setup
+
+1. Install Angular CLI (requires Node.js):
+   ```bash
+   npm install -g @angular/cli
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the development server:
+   ```bash
+   ng serve
+   ```
+4. Navigate to `http://localhost:4200/` in your browser.
+
+## Screenshots
+
+Add screenshots of the dashboard and inventory pages here once the app is running.
+
+## Notes
+
+This repository contains only the source code. Dependencies must be installed using `npm install` before running or testing the application.

--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "inventory-system": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/inventory-system",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "inventory-system:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "inventory-system:build:production"
+            }
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "inventory-system"
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,33 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "inventory-system",
+  "version": "0.0.1",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^17.0.0",
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "@angular/router": "^17.0.0",
+    "@angular/material": "^17.0.0",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.1",
+    "chart.js": "^4.4.0",
+    "ng2-charts": "^4.0.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.0.0",
+    "@angular/cli": "^17.0.0",
+    "@angular/compiler-cli": "^17.0.0",
+    "@types/node": "^18.0.0",
+    "typescript": "~5.1.6",
+    "karma": "~6.4.2",
+    "karma-chrome-launcher": "~3.1.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "jasmine-core": "~5.1.0",
+    "jasmine-spec-reporter": "~7.2.0"
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,11 @@
+<mat-toolbar color="primary">
+  <button mat-icon-button [routerLink]="['/']">
+    <mat-icon>home</mat-icon>
+  </button>
+  <span>{{ title }}</span>
+  <span class="spacer"></span>
+  <a mat-button routerLink="/">Dashboard</a>
+  <a mat-button routerLink="/inventory">Inventory</a>
+</mat-toolbar>
+
+<router-outlet></router-outlet>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,3 @@
+.spacer {
+  flex: 1 1 auto;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
+})
+export class AppComponent {
+  title = 'Inventory System';
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+import { AppComponent } from './app.component';
+import { routes } from './app.routes';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    RouterModule.forRoot(routes)
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,0 +1,13 @@
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+  {
+    path: '',
+    loadChildren: () => import('./features/dashboard/dashboard.module').then(m => m.DashboardModule)
+  },
+  {
+    path: 'inventory',
+    loadChildren: () => import('./features/inventory/inventory.module').then(m => m.InventoryModule)
+  },
+  { path: '**', redirectTo: '' }
+];

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,0 +1,3 @@
+<mat-card>
+  <canvas baseChart [data]="chartConfig.data" [type]="chartConfig.type"></canvas>
+</mat-card>

--- a/src/app/features/dashboard/dashboard.component.scss
+++ b/src/app/features/dashboard/dashboard.component.scss
@@ -1,0 +1,3 @@
+mat-card {
+  margin: 1rem;
+}

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from '@angular/core';
+import { ChartConfiguration } from 'chart.js';
+import { InventoryService } from '../inventory/inventory.service';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent implements OnInit {
+  chartConfig: ChartConfiguration<'bar'> = {
+    type: 'bar',
+    data: {
+      labels: [],
+      datasets: [
+        { data: [], label: 'Quantity' }
+      ]
+    }
+  };
+
+  constructor(private inventoryService: InventoryService) {}
+
+  ngOnInit(): void {
+    this.inventoryService.items$.subscribe(items => {
+      this.chartConfig.data.labels = items.map(i => i.name);
+      this.chartConfig.data.datasets[0].data = items.map(i => i.quantity);
+    });
+  }
+}

--- a/src/app/features/dashboard/dashboard.module.ts
+++ b/src/app/features/dashboard/dashboard.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { ChartsModule } from 'ng2-charts';
+
+import { DashboardComponent } from './dashboard.component';
+
+const routes: Routes = [
+  { path: '', component: DashboardComponent }
+];
+
+@NgModule({
+  declarations: [DashboardComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatToolbarModule,
+    ChartsModule,
+    RouterModule.forChild(routes)
+  ]
+})
+export class DashboardModule {}

--- a/src/app/features/inventory/components/inventory-detail.component.html
+++ b/src/app/features/inventory/components/inventory-detail.component.html
@@ -1,0 +1,20 @@
+<mat-card>
+  <form [formGroup]="form" (ngSubmit)="save()">
+    <mat-form-field appearance="fill">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" required>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Quantity</mat-label>
+      <input matInput type="number" formControlName="quantity" required>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Price</mat-label>
+      <input matInput type="number" formControlName="price" required>
+    </mat-form-field>
+
+    <button mat-raised-button color="primary" type="submit">Save</button>
+  </form>
+</mat-card>

--- a/src/app/features/inventory/components/inventory-detail.component.scss
+++ b/src/app/features/inventory/components/inventory-detail.component.scss
@@ -1,0 +1,9 @@
+mat-card {
+  max-width: 400px;
+  margin: 1rem auto;
+  display: block;
+}
+
+mat-form-field {
+  width: 100%;
+}

--- a/src/app/features/inventory/components/inventory-detail.component.ts
+++ b/src/app/features/inventory/components/inventory-detail.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormBuilder, Validators } from '@angular/forms';
+import { InventoryService } from '../inventory.service';
+import { Item } from '../item.model';
+
+@Component({
+  selector: 'app-inventory-detail',
+  templateUrl: './inventory-detail.component.html',
+  styleUrls: ['./inventory-detail.component.scss']
+})
+export class InventoryDetailComponent implements OnInit {
+  form = this.fb.nonNullable.group({
+    id: [0],
+    name: ['', Validators.required],
+    quantity: [0, Validators.required],
+    price: [0, Validators.required]
+  });
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private inventoryService: InventoryService
+  ) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    if (id) {
+      this.inventoryService.getItem(id).subscribe(item => {
+        if (item) this.form.patchValue(item);
+      });
+    }
+  }
+
+  save(): void {
+    const item: Item = this.form.getRawValue();
+    if (item.id) {
+      this.inventoryService.updateItem(item);
+    } else {
+      item.id = Date.now();
+      this.inventoryService.addItem(item);
+    }
+    this.router.navigate(['/inventory']);
+  }
+}

--- a/src/app/features/inventory/components/inventory-list.component.html
+++ b/src/app/features/inventory/components/inventory-list.component.html
@@ -1,0 +1,39 @@
+<mat-toolbar color="accent">
+  <span>Inventory</span>
+  <span class="spacer"></span>
+  <button mat-raised-button color="primary" routerLink="/inventory/new">Add Item</button>
+</mat-toolbar>
+
+<mat-form-field appearance="outline" class="search-field">
+  <mat-label>Search</mat-label>
+  <input matInput [(ngModel)]="search">
+</mat-form-field>
+
+<table mat-table [dataSource]="items$ | async | search:search" class="mat-elevation-z8">
+  <ng-container matColumnDef="id">
+    <th mat-header-cell *matHeaderCellDef>ID</th>
+    <td mat-cell *matCellDef="let item">{{ item.id }}</td>
+  </ng-container>
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <td mat-cell *matCellDef="let item">{{ item.name }}</td>
+  </ng-container>
+  <ng-container matColumnDef="quantity">
+    <th mat-header-cell *matHeaderCellDef>Qty</th>
+    <td mat-cell *matCellDef="let item">{{ item.quantity }}</td>
+  </ng-container>
+  <ng-container matColumnDef="price">
+    <th mat-header-cell *matHeaderCellDef>Price</th>
+    <td mat-cell *matCellDef="let item">{{ item.price | currency }}</td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef></th>
+    <td mat-cell *matCellDef="let item">
+      <button mat-icon-button (click)="view(item.id)"><mat-icon>edit</mat-icon></button>
+      <button mat-icon-button color="warn" (click)="delete(item.id)"><mat-icon>delete</mat-icon></button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/src/app/features/inventory/components/inventory-list.component.scss
+++ b/src/app/features/inventory/components/inventory-list.component.scss
@@ -1,0 +1,8 @@
+.search-field {
+  width: 100%;
+  margin: 1rem 0;
+}
+
+table {
+  width: 100%;
+}

--- a/src/app/features/inventory/components/inventory-list.component.ts
+++ b/src/app/features/inventory/components/inventory-list.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { Item } from '../item.model';
+import { InventoryService } from '../inventory.service';
+
+@Component({
+  selector: 'app-inventory-list',
+  templateUrl: './inventory-list.component.html',
+  styleUrls: ['./inventory-list.component.scss']
+})
+export class InventoryListComponent {
+  displayedColumns = ['id', 'name', 'quantity', 'price', 'actions'];
+  items$: Observable<Item[]> = this.inventoryService.items$;
+  search = '';
+
+  constructor(private inventoryService: InventoryService, private router: Router) {}
+
+  view(id: number): void {
+    this.router.navigate(['/inventory', id]);
+  }
+
+  delete(id: number): void {
+    this.inventoryService.deleteItem(id);
+  }
+}

--- a/src/app/features/inventory/inventory.module.ts
+++ b/src/app/features/inventory/inventory.module.ts
@@ -1,0 +1,42 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatCardModule } from '@angular/material/card';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { HttpClientModule } from '@angular/common/http';
+
+import { InventoryListComponent } from './components/inventory-list.component';
+import { InventoryDetailComponent } from './components/inventory-detail.component';
+import { InventoryService } from './inventory.service';
+import { SearchPipe } from './search.pipe';
+
+const routes: Routes = [
+  { path: '', component: InventoryListComponent },
+  { path: 'new', component: InventoryDetailComponent },
+  { path: ':id', component: InventoryDetailComponent }
+];
+
+@NgModule({
+  declarations: [InventoryListComponent, InventoryDetailComponent, SearchPipe],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatCardModule,
+    MatToolbarModule,
+    HttpClientModule,
+    RouterModule.forChild(routes)
+  ]
+})
+export class InventoryModule {}

--- a/src/app/features/inventory/inventory.service.ts
+++ b/src/app/features/inventory/inventory.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Item } from './item.model';
+
+@Injectable({ providedIn: 'root' })
+export class InventoryService {
+  private itemsSubject = new BehaviorSubject<Item[]>([]);
+  items$ = this.itemsSubject.asObservable();
+
+  constructor(private http: HttpClient) {
+    this.loadItems();
+  }
+
+  private loadItems(): void {
+    this.http.get<Item[]>('assets/data/inventory.json')
+      .subscribe(data => this.itemsSubject.next(data));
+  }
+
+  getItem(id: number): Observable<Item | undefined> {
+    return this.items$.pipe(map(items => items.find(i => i.id === id)));
+  }
+
+  addItem(item: Item): void {
+    const items = this.itemsSubject.getValue();
+    this.itemsSubject.next([...items, item]);
+  }
+
+  updateItem(updated: Item): void {
+    const items = this.itemsSubject.getValue().map(item => item.id === updated.id ? updated : item);
+    this.itemsSubject.next(items);
+  }
+
+  deleteItem(id: number): void {
+    const items = this.itemsSubject.getValue().filter(item => item.id !== id);
+    this.itemsSubject.next(items);
+  }
+}

--- a/src/app/features/inventory/item.model.ts
+++ b/src/app/features/inventory/item.model.ts
@@ -1,0 +1,6 @@
+export interface Item {
+  id: number;
+  name: string;
+  quantity: number;
+  price: number;
+}

--- a/src/app/features/inventory/search.pipe.ts
+++ b/src/app/features/inventory/search.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Item } from './item.model';
+
+@Pipe({ name: 'search' })
+export class SearchPipe implements PipeTransform {
+  transform(items: Item[], query: string): Item[] {
+    if (!query) return items;
+    const lower = query.toLowerCase();
+    return items.filter(i => i.name.toLowerCase().includes(lower));
+  }
+}

--- a/src/assets/data/inventory.json
+++ b/src/assets/data/inventory.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "name": "Item 1", "quantity": 10, "price": 20 },
+  { "id": 2, "name": "Item 2", "quantity": 5, "price": 50 },
+  { "id": 3, "name": "Item 3", "quantity": 15, "price": 30 }
+]

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false
+};

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>InventorySystem</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,17 @@
+@use '@angular/material' as mat;
+@include mat.core();
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}
+
+.mat-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2022",
+    "module": "es2022",
+    "types": [],
+    "lib": ["es2022", "dom"]
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "files": [
+    "src/test.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- initialize Angular workspace files
- add dashboard and inventory feature modules
- implement inventory service with CRUD logic
- provide Material UI components and search pipe
- document setup instructions in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e88e22978832b9eaf0ba5887e15c0